### PR TITLE
Positioning X-UA-Compatible META tag Near <head>

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Snake</title>
   <style>
     body {


### PR DESCRIPTION
You should position the X-UA-Compatible META tag as near to the HEAD of the page as you can if you're utilizing it.
Reference: https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do